### PR TITLE
[FEAT] 월별 일정(카테고리) 조회 기능 추가

### DIFF
--- a/src/main/java/com/example/ohmobackend/converter/ScheduleConverter.java
+++ b/src/main/java/com/example/ohmobackend/converter/ScheduleConverter.java
@@ -3,11 +3,14 @@ package com.example.ohmobackend.converter;
 import com.example.ohmobackend.domain.MemberCategory;
 import com.example.ohmobackend.domain.Schedule;
 import com.example.ohmobackend.domain.enums.ScheduleType;
+import com.example.ohmobackend.web.dto.memberCategoryDto.MemberCategoryResponseDto;
 import com.example.ohmobackend.web.dto.scheduleDto.ScheduleRequestDto;
 import com.example.ohmobackend.web.dto.scheduleDto.ScheduleResponseDto;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class ScheduleConverter {
 
@@ -52,6 +55,24 @@ public class ScheduleConverter {
                 .status(schedule.isStatus())
                 .scheduleType(schedule.getScheduleType())
                 .category(MemberCategoryConverter.toAddCategoryResponseDto(schedule.getMemberCategory()))
+                .build();
+    }
+
+    static public ScheduleResponseDto.ScheduleByMonthDto toScheduleByMonthDto(List<Schedule> scheduleList, LocalDate date) {
+
+        List<MemberCategoryResponseDto.CategoryResponseDto> categoryList = scheduleList.stream()
+                .map(schedule -> MemberCategoryConverter.toAddCategoryResponseDto(schedule.getMemberCategory()))
+                .collect(Collectors.toMap(
+                        category -> category.getId(),  // 중복을 제거할 기준 필드
+                        category -> category,
+                        (existing, replacement) -> existing))
+                .values()
+                .stream()
+                .collect(Collectors.toList());
+
+        return ScheduleResponseDto.ScheduleByMonthDto.builder()
+                .date(date)
+                .categoryList(categoryList)
                 .build();
     }
 

--- a/src/main/java/com/example/ohmobackend/repository/MemberCategoryRepository.java
+++ b/src/main/java/com/example/ohmobackend/repository/MemberCategoryRepository.java
@@ -10,4 +10,5 @@ import java.util.List;
 public interface MemberCategoryRepository extends JpaRepository<MemberCategory, Long> {
 
     public List<MemberCategory> findByMemberAndScheduleType(Member member, ScheduleType scheduleType);
+    public List<MemberCategory> findByMember(Member member);
 }

--- a/src/main/java/com/example/ohmobackend/repository/ScheduleRepository.java
+++ b/src/main/java/com/example/ohmobackend/repository/ScheduleRepository.java
@@ -12,4 +12,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     @Query("SELECT s FROM Schedule s WHERE s.memberCategory = :memberCategory AND s.date = :date")
     public List<Schedule> findByMemberCategoryAndDate(MemberCategory memberCategory, LocalDate date);
+
+    @Query("SELECT s FROM Schedule s WHERE s.memberCategory = :memberCategory AND FUNCTION('DATE_FORMAT', s.date, '%Y-%m') = :month")
+    public List<Schedule> findByMemberCategoryAndMonth(MemberCategory memberCategory, String month);
 }

--- a/src/main/java/com/example/ohmobackend/service/scheduleService/ScheduleQueryService.java
+++ b/src/main/java/com/example/ohmobackend/service/scheduleService/ScheduleQueryService.java
@@ -10,4 +10,6 @@ import java.util.List;
 public interface ScheduleQueryService {
 
     public List<ScheduleResponseDto.ScheduleDto> getScheduleList(LocalDate date, Member member, ScheduleType scheduleType);
+
+    public List<ScheduleResponseDto.ScheduleByMonthDto> getScheduleListByMonth(String month, Member member);
 }

--- a/src/main/java/com/example/ohmobackend/service/scheduleService/ScheduleQueryServiceImpl.java
+++ b/src/main/java/com/example/ohmobackend/service/scheduleService/ScheduleQueryServiceImpl.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -33,13 +34,10 @@ public class ScheduleQueryServiceImpl implements ScheduleQueryService {
             throw new MemberCategoryHandler(ErrorStatus.MEMBER_CATEGORY_NOT_FOUND);
         }
 
-        System.out.println(memberCategoryList.get(0).getId());
-
         List<Schedule> scheduleList = memberCategoryList.stream()
                 .map(memberCategory -> {
                     List<Schedule> schedules = scheduleRepository.findByMemberCategoryAndDate(memberCategory, date);
                     if (schedules.isEmpty()) {
-                        System.out.println(date);
                         throw new ScheduleHandler(ErrorStatus.SCHEDULE_NOT_EXIST);
                     }
                     return schedules;
@@ -49,6 +47,42 @@ public class ScheduleQueryServiceImpl implements ScheduleQueryService {
 
         return scheduleList.stream()
                 .map(schedule -> ScheduleConverter.toScheduleDto(schedule))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<ScheduleResponseDto.ScheduleByMonthDto> getScheduleListByMonth(String yearMonth, Member member) {
+        List<MemberCategory> memberCategoryList = memberCategoryRepository.findByMember(member);
+
+        if (memberCategoryList.isEmpty()) {
+            throw new MemberCategoryHandler(ErrorStatus.MEMBER_CATEGORY_NOT_FOUND);
+        }
+
+        List<Schedule> scheduleList = memberCategoryList.stream()
+                .map(memberCategory -> {
+                    List<Schedule> schedules = scheduleRepository.findByMemberCategoryAndMonth(memberCategory, yearMonth);
+                    if (schedules.isEmpty()) {
+                        throw new ScheduleHandler(ErrorStatus.SCHEDULE_NOT_EXIST);
+                    }
+                    return schedules;
+                })
+                .flatMap(List::stream)  // List<Schedule>을 평탄화하여 하나의 스트림으로 변환
+                .collect(Collectors.toList());
+
+        // 날짜별로 그룹화
+        Map<LocalDate, List<Schedule>> groupedByDate = scheduleList.stream()
+                .collect(Collectors.groupingBy(Schedule::getDate));
+
+        // 날짜순으로 정렬
+        List<LocalDate> sortedDates = groupedByDate.keySet().stream()
+                .sorted()
+                .collect(Collectors.toList());
+
+        return sortedDates.stream()
+                .map(date -> {
+                    List<Schedule> schedulesForDate = groupedByDate.get(date);
+                    return ScheduleConverter.toScheduleByMonthDto(schedulesForDate, date);
+                })
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/ohmobackend/web/controller/ScheduleController.java
+++ b/src/main/java/com/example/ohmobackend/web/controller/ScheduleController.java
@@ -47,10 +47,17 @@ public class ScheduleController {
         return ApiResponse.onSuccess(SuccessStatus.SCHEDULE_UPDATE_STATUS_OK, null);
     }
 
-    @GetMapping("/")
-    @Operation(summary = "상태 변경 API", description = "상태 변경 API 입니다.")
+    @GetMapping("/by-date")
+    @Operation(summary = "일별 일정 조회 API", description = "일별 일정 조회 API 입니다.")
     public ApiResponse<List<ScheduleResponseDto.ScheduleDto>> getScheduleList(@RequestParam(name = "date")LocalDate date, @RequestParam(name = "type")ScheduleType scheduleType, @AuthUser Member member) {
         List<ScheduleResponseDto.ScheduleDto> scheduleDtoList = scheduleQueryService.getScheduleList(date, member, scheduleType);
+        return ApiResponse.onSuccess(SuccessStatus.SCHEDULE_OK, scheduleDtoList);
+    }
+
+    @GetMapping("/by-month")
+    @Operation(summary = "월별 일정 조회 API", description = "월별 일정 조회 API 입니다.")
+    public ApiResponse<List<ScheduleResponseDto.ScheduleByMonthDto>> getScheduleListByMonth(@RequestParam(name = "yearMonth")String yearMonth, @AuthUser Member member) {
+        List<ScheduleResponseDto.ScheduleByMonthDto> scheduleDtoList = scheduleQueryService.getScheduleListByMonth(yearMonth, member);
         return ApiResponse.onSuccess(SuccessStatus.SCHEDULE_OK, scheduleDtoList);
     }
 }

--- a/src/main/java/com/example/ohmobackend/web/dto/scheduleDto/ScheduleResponseDto.java
+++ b/src/main/java/com/example/ohmobackend/web/dto/scheduleDto/ScheduleResponseDto.java
@@ -1,8 +1,6 @@
 package com.example.ohmobackend.web.dto.scheduleDto;
 
-import com.example.ohmobackend.domain.MemberCategory;
 import com.example.ohmobackend.domain.enums.ScheduleType;
-import com.example.ohmobackend.security.JwtToken;
 import com.example.ohmobackend.web.dto.memberCategoryDto.MemberCategoryResponseDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -11,6 +9,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 
 public class ScheduleResponseDto {
 
@@ -27,5 +26,14 @@ public class ScheduleResponseDto {
         private boolean status;
         private ScheduleType scheduleType;
         private MemberCategoryResponseDto.CategoryResponseDto category;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ScheduleByMonthDto {
+        private LocalDate date;
+        private List<MemberCategoryResponseDto.CategoryResponseDto> categoryList;
     }
 }


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 월별 일정(카테고리) 조회 기능 추가
- 해당 월과 일치하는 schedule 모두 조회
- Schdule을 같은 날짜별로 map형태로 그룹화
- 그룹화한 일정들을 날짜순으로 정렬하고 카테고리 반환

## 📌 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 리뷰를 원하는 부분 등을 적어주세요! -->
- 내용

### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #25
