### PR TITLE
[FIX] 루틴 조회 쿼리 수정

### DIFF
--- a/src/main/java/com/example/ohmobackend/repository/RoutineRepository.java
+++ b/src/main/java/com/example/ohmobackend/repository/RoutineRepository.java
@@ -13,11 +13,11 @@ import java.util.List;
 
 public interface RoutineRepository extends JpaRepository<Routine, Long> {
 
-    @Query("SELECT DISTINCT r FROM Routine r " +
-            "JOIN FETCH r.schedule s " +
-            "JOIN FETCH s.memberCategory mc " +
-            "WHERE r.date = :date " +
-            "AND mc.member = :member")
+    @Query("SELECT r FROM MemberCategory mc " +
+            "JOIN mc.scheduleList s " +
+            "JOIN s.routineList r " +
+            "WHERE mc.member = :member " +
+            "AND r.date = :date")
     List<Routine> findRoutinesWithScheduleByMemberAndDate(
             @Param("member") Member member,
             @Param("date") LocalDate date


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 기존에는 routine에서 특정 날짜로 먼저 스캔 -> 내 routine이 아니라도 날짜가 같으면 필터링 됐음 
- Routine 엔티티 중심의 조회를 MemberCategory 기반의 조회로 리팩토링
- '나의 카테고리'를 먼저 필터링한 후 관련 일정/루틴을 타고 내려가는 방식으로 개선.

## 📌 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 리뷰를 원하는 부분 등을 적어주세요! -->
- 내용

### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #
