### PR TITLE
[FIX] 그룹 일정 조회 기능 N+1 제거

### DIFF
--- a/src/main/java/com/example/ohmobackend/repository/RoutineRepository.java
+++ b/src/main/java/com/example/ohmobackend/repository/RoutineRepository.java
@@ -47,4 +47,15 @@ public interface RoutineRepository extends JpaRepository<Routine, Long> {
 
     List<Routine> findAllBySchedule(Schedule schedule);
 
+    @Query("SELECT r FROM Routine r " +
+            "JOIN FETCH r.schedule s " +
+            "LEFT JOIN FETCH r.scheduleAssigneeList a " +
+            "LEFT JOIN FETCH a.memberGroup mg " +
+            "LEFT JOIN FETCH mg.member m " +
+            "WHERE s.group = :group AND r.date = :date")
+    List<Routine> findRoutinesWithScheduleAndAssignees(
+            @Param("group") Group group,
+            @Param("date") LocalDate date
+    );
+
 }

--- a/src/main/java/com/example/ohmobackend/repository/ScheduleAssigneeRepository.java
+++ b/src/main/java/com/example/ohmobackend/repository/ScheduleAssigneeRepository.java
@@ -5,11 +5,22 @@ import com.example.ohmobackend.domain.Schedule;
 import com.example.ohmobackend.domain.ScheduleAssignee;
 import com.example.ohmobackend.domain.Todo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface ScheduleAssigneeRepository extends JpaRepository<ScheduleAssignee, Long> {
 
+    @Query("SELECT s FROM ScheduleAssignee s " +
+            "JOIN FETCH s.memberGroup mg " +
+            "JOIN FETCH mg.member " +
+            "WHERE s.todo = :todo"
+    )
     public List<ScheduleAssignee> findAllByTodo(Todo todo);
+
+    @Query("SELECT s FROM ScheduleAssignee s " +
+            "JOIN FETCH s.memberGroup mg " +
+            "JOIN FETCH mg.member " +
+            "WHERE s.routine = :routine")
     public List<ScheduleAssignee> findAllByRoutine(Routine routine);
 }

--- a/src/main/java/com/example/ohmobackend/repository/ScheduleRepository.java
+++ b/src/main/java/com/example/ohmobackend/repository/ScheduleRepository.java
@@ -64,4 +64,16 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             @Param("date") LocalDate date,
             @Param("scheduleType") ScheduleType scheduleType);
 
+
+    @Query("SELECT s FROM Schedule s " +
+            "JOIN FETCH s.todo t " +
+            "LEFT JOIN FETCH t.scheduleAssigneeList a " +
+            "LEFT JOIN FETCH a.memberGroup mg " +
+            "LEFT JOIN FETCH mg.member " +
+            "WHERE s.group = :group AND s.date = :date AND s.scheduleType = :scheduleType")
+    List<Schedule> findSchedulesWithTodoAndAssignees(
+            @Param("group") Group group,
+            @Param("date") LocalDate date,
+            @Param("scheduleType") ScheduleType scheduleType);
+
 }

--- a/src/main/java/com/example/ohmobackend/service/scheduleService/GroupScheduleQueryServiceImpl.java
+++ b/src/main/java/com/example/ohmobackend/service/scheduleService/GroupScheduleQueryServiceImpl.java
@@ -35,11 +35,11 @@ public class GroupScheduleQueryServiceImpl implements GroupScheduleQueryService 
                 .orElseThrow(() -> new GroupHandler(ErrorStatus.GROUP_NOT_FOUND));
 
         // 투두 찾기
-        List<Schedule> todoSchedules = scheduleRepository.findSchedulesWithTodoByGroupAndDateAndScheduleType(group, date, ScheduleType.TO_DO);
+        List<Schedule> todoSchedules = scheduleRepository.findSchedulesWithTodoAndAssignees(group, date, ScheduleType.TO_DO);
         List<GroupScheduleResponseDto.GroupScheduleTodoDto> groupScheduleTodoDtos = getScheduleTodoDtos(todoSchedules);
 
         // 루틴 찾기
-        List<Routine> rotiunes = routineRepository.findRoutinesWithScheduleByGroupAndDate(group, date);
+        List<Routine> rotiunes = routineRepository.findRoutinesWithScheduleAndAssignees(group, date);
         List<GroupScheduleResponseDto.GroupScheduleRoutineDto> groupScheduleRoutineDtos = getScheduleRoutineDtos(rotiunes);
         return GroupScheduleConverter.toGroupSchedulesDto(groupScheduleTodoDtos, groupScheduleRoutineDtos);
     }
@@ -47,8 +47,8 @@ public class GroupScheduleQueryServiceImpl implements GroupScheduleQueryService 
     private List<GroupScheduleResponseDto.GroupScheduleTodoDto> getScheduleTodoDtos(List<Schedule> todoSchedules) {
         return todoSchedules.stream()
                 .map(s -> {
-                    List<ScheduleAssignee> scheduleAssignees = scheduleAssigneeRepository.findAllByTodo(s.getTodo());
-                    return GroupScheduleConverter.toGroupScheduleTodoDto(s, scheduleAssignees);
+                    List<ScheduleAssignee> assignees = s.getTodo().getScheduleAssigneeList();
+                    return GroupScheduleConverter.toGroupScheduleTodoDto(s, assignees);
                 })
                 .collect(Collectors.toList());
     }
@@ -56,8 +56,8 @@ public class GroupScheduleQueryServiceImpl implements GroupScheduleQueryService 
     private List<GroupScheduleResponseDto.GroupScheduleRoutineDto> getScheduleRoutineDtos(List<Routine> routines) {
         return routines.stream()
                 .map(r -> {
-                    List<ScheduleAssignee> scheduleAssignees = scheduleAssigneeRepository.findAllByRoutine(r);
-                    return GroupScheduleConverter.toGroupScheduleRoutineDto(r, r.getSchedule(), scheduleAssignees);
+                    List<ScheduleAssignee> assignees = r.getScheduleAssigneeList();
+                    return GroupScheduleConverter.toGroupScheduleRoutineDto(r, r.getSchedule(), assignees);
                 })
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 루틴,투두 조회시 루틴 담당자(ScheduleAssignee), 담당자 정보(member) Fetch join
- n+1 제거
- 전체 일정 조회 쿼리 **1번**, 각 일정마다 할당자를 찾는 쿼리 **10번** -> N + 1 문제

## 📌 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 리뷰를 원하는 부분 등을 적어주세요! -->
- 내용

### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #77
