### PR TITLE
[FEAT] Circuit Breaker 도입 AI API 호출 안정성 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     testImplementation 'com.h2database:h2'
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/ohmobackend/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/ohmobackend/apiPayload/code/status/ErrorStatus.java
@@ -45,6 +45,8 @@ public enum ErrorStatus implements BaseErrorCode {
     SCHEDULE_INVALID_ALARM_TIME(HttpStatus.BAD_REQUEST, "SCHEDULE4005", "알람 시간 등록이 불가능한 일정입니다."),
     SCHEDULE_NOT_GROUP_TYPE(HttpStatus.BAD_REQUEST, "SCHEDULE4006", "그룹 일정이 아닙니다."),
     NLP_PARSE_FAILED(HttpStatus.BAD_REQUEST, "SCHEDULE4007", "텍스트 파싱 실패"),
+    NLP_SERVER_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "SCHEDULE5001", "AI 서버 응답 시간이 초과되었습니다. 잠시 후 다시 시도해주세요."),
+    NLP_SERVER_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "SCHEDULE5002", "AI 서버를 현재 사용할 수 없습니다. 잠시 후 다시 시도해주세요."),
 
     // 질문 관련
     QUESTION_NOT_FOUND(HttpStatus.BAD_REQUEST, "QUESTION4001", "등록된 질문이 없습니다."),

--- a/src/main/java/com/example/ohmobackend/config/RestClientConfig.java
+++ b/src/main/java/com/example/ohmobackend/config/RestClientConfig.java
@@ -1,0 +1,21 @@
+package com.example.ohmobackend.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    public RestTemplate nlpRestTemplate(
+            @Value("${nlp.connect-timeout}") int connectTimeout,
+            @Value("${nlp.read-timeout}") int readTimeout) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(connectTimeout);
+        factory.setReadTimeout(readTimeout);
+        return new RestTemplate(factory);
+    }
+}

--- a/src/main/java/com/example/ohmobackend/service/scheduleService/NlpApiClient.java
+++ b/src/main/java/com/example/ohmobackend/service/scheduleService/NlpApiClient.java
@@ -1,0 +1,56 @@
+package com.example.ohmobackend.service.scheduleService;
+
+import com.example.ohmobackend.apiPayload.code.status.ErrorStatus;
+import com.example.ohmobackend.apiPayload.exception.handler.ScheduleHandler;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Component
+@Slf4j
+public class NlpApiClient {
+
+    private final RestTemplate nlpRestTemplate;
+
+    @Value("${nlp.api-url}")
+    private String nlpApiUrl;
+
+    public NlpApiClient(@Qualifier("nlpRestTemplate") RestTemplate nlpRestTemplate) {
+        this.nlpRestTemplate = nlpRestTemplate;
+    }
+
+    @CircuitBreaker(name = "nlpApi", fallbackMethod = "fallback")
+    public Map<String, Object> extractSchedule(String text) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.TEXT_PLAIN);
+        HttpEntity<String> entity = new HttpEntity<>(text, headers);
+
+        ResponseEntity<Map> response = nlpRestTemplate.postForEntity(
+                nlpApiUrl + "/nlp/extract-text", entity, Map.class);
+
+        if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
+            throw new ScheduleHandler(ErrorStatus.NLP_PARSE_FAILED);
+        }
+
+        return (Map<String, Object>) response.getBody().get("result");
+    }
+
+    private Map<String, Object> fallback(String text, Exception e) {
+        log.error("NLP API 호출 실패: {}", e.getMessage());
+        if (e instanceof ResourceAccessException) {
+            throw new ScheduleHandler(ErrorStatus.NLP_SERVER_TIMEOUT);
+        }
+        throw new ScheduleHandler(ErrorStatus.NLP_SERVER_UNAVAILABLE);
+    }
+}

--- a/src/main/java/com/example/ohmobackend/service/scheduleService/ScheduleCommandServiceImpl.java
+++ b/src/main/java/com/example/ohmobackend/service/scheduleService/ScheduleCommandServiceImpl.java
@@ -16,13 +16,8 @@ import com.example.ohmobackend.web.dto.scheduleDto.ScheduleResponseDto;
 import com.example.ohmobackend.web.dto.todoDto.TodoResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestTemplate;
 
 import java.time.LocalDate;
 import java.util.HashSet;
@@ -40,8 +35,7 @@ import static com.example.ohmobackend.service.scheduleService.DateCalculator.get
 @Transactional
 public class ScheduleCommandServiceImpl implements ScheduleCommandService {
 
-    @Value("${nlp.api-url}")
-    private String nlpApiUrl;
+    final private NlpApiClient nlpApiClient;
     final private MemberCategoryRepository memberCategoryRepository;
     final private ScheduleRepository scheduleRepository;
     final private TodoRepository todoRepository;
@@ -106,7 +100,7 @@ public class ScheduleCommandServiceImpl implements ScheduleCommandService {
 
     @Override
     public TodoResponseDto.TodoDto nlpAddTodo(ScheduleRequestDto.NlpAddRequestDto requestDto, Member member) {
-        Map<String, Object> parsedResult = callNlpApi(requestDto.getText());
+        Map<String, Object> parsedResult = nlpApiClient.extractSchedule(requestDto.getText());
         MemberCategory memberCategory = memberCategoryRepository.findByMemberAndCategoryNameAndScheduleType(
                         member, "default", ScheduleType.TO_DO)
                 .orElseThrow(() -> new MemberCategoryHandler(ErrorStatus.MEMBER_CATEGORY_NOT_FOUND));
@@ -274,18 +268,5 @@ public class ScheduleCommandServiceImpl implements ScheduleCommandService {
                 .toList();
     }
 
-    private Map<String, Object> callNlpApi(String text) {
-        RestTemplate restTemplate = new RestTemplate();
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.TEXT_PLAIN);
-        HttpEntity<String> entity = new HttpEntity<>(text, headers);
 
-        ResponseEntity<Map> response = restTemplate.postForEntity(nlpApiUrl + "/nlp/extract-text", entity, Map.class);
-
-        if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
-            throw new ScheduleHandler(ErrorStatus.NLP_PARSE_FAILED);
-        }
-
-        return (Map<String, Object>) response.getBody().get("result");
-    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,7 +29,7 @@ spring:
     show-sql: false
   data:
     redis:
-      host: redis
+      host: localhost
       port: 6379
   mail:
     host: smtp.gmail.com
@@ -52,6 +52,20 @@ jwt:
 
 nlp:
   api-url: "http://localhost:8000"
+  connect-timeout: 3000
+  read-timeout: 10000
+
+resilience4j:
+  circuitbreaker:
+    instances:
+      nlpApi:
+        registerHealthIndicator: true
+        slidingWindowSize: 10
+        failureRateThreshold: 50
+        waitDurationInOpenState: 30s
+        permittedNumberOfCallsInHalfOpenState: 3
+        recordExceptions:
+          - org.springframework.web.client.ResourceAccessException
 
 management:
   endpoints:


### PR DESCRIPTION
  ## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- RestTemplate에 connectTimeout(3s)/readTimeout(10s) 설정으로 스레드 무한 점유 방지
 - NlpApiClient 분리 및 @CircuitBreaker 적용으로 AI 서버 지속 장애 시 즉시 실패 반환
 - 연결 실패/서킷 오픈 상황에 대한 명확한 에러 응답 추가 (NLP_SERVER_TIMEOUT, NLP_SERVER_UNAVAILABLE)

## 📌 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 리뷰를 원하는 부분 등을 적어주세요! -->
- 내용

### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #101
