### PR TITLE
[FEAT] 그룹 멤버 강퇴 API, 그룹 투두 AI로 등록 API 추가

### DIFF
--- a/src/main/java/com/example/ohmobackend/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/ohmobackend/apiPayload/code/status/ErrorStatus.java
@@ -63,6 +63,7 @@ public enum ErrorStatus implements BaseErrorCode {
     GROUP_MEMBER_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "GROUP4004", "그룹 최대 인원을 초과했습니다."),
     GROUP_MANAGER_CANNOT_LEAVE(HttpStatus.BAD_REQUEST, "GROUP4005", "그룹 매니저는 다른 멤버가 있을 경우 그룹을 나갈 수 없습니다."),
     GROUP_NOT_MANAGER(HttpStatus.BAD_REQUEST, "GROUP4006", "그룹 매니저만 방장을 넘길 수 있습니다."),
+    GROUP_CANNOT_KICK_MANAGER(HttpStatus.BAD_REQUEST, "GROUP4007", "매니저는 강퇴할 수 없습니다."),
 
     // 루틴
     ROUTINE_NOT_FOUND(HttpStatus.BAD_REQUEST, "ROUTINE4001", "루틴을 찾을 수 없습니다."),

--- a/src/main/java/com/example/ohmobackend/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/example/ohmobackend/apiPayload/code/status/SuccessStatus.java
@@ -62,6 +62,7 @@ public enum SuccessStatus implements BaseCode {
     GROUP_DELETE_OK(HttpStatus.OK, "GROUP_2005", "그룹 삭제가 완료되었습니다."),
     GROUP_LEAVE_OK(HttpStatus.OK, "GROUP_2006", "그룹 나가기가 완료되었습니다."),
     GROUP_TRANSFER_MANAGER_OK(HttpStatus.OK, "GROUP_2007", "방장 넘기기가 완료되었습니다."),
+    GROUP_KICK_MEMBER_OK(HttpStatus.OK, "GROUP_2008", "그룹 멤버 강퇴가 완료되었습니다."),
 
     // 공지사항 관련
     GROUP_NOTICE_REGISTER_OK(HttpStatus.OK, "GROUP_2001", "그룹 공지사항 등록이 완료되었습니다."),

--- a/src/main/java/com/example/ohmobackend/converter/ScheduleConverter.java
+++ b/src/main/java/com/example/ohmobackend/converter/ScheduleConverter.java
@@ -68,6 +68,27 @@ public class ScheduleConverter {
         return null;
     }
 
+    static public Schedule parsedResultToGroupScheduleEntity(
+            Map<String, Object> parsedResult,
+            Group group,
+            MemberGroup memberGroup) {
+
+        LocalDate date = parseDate(parsedResult.get("date"));
+        LocalTime time = parseTime(parsedResult.get("time"));
+        LocalTime alarmTime = parseTime(parsedResult.get("alarm_time"));
+
+        return Schedule.builder()
+                .date(date)
+                .time(time)
+                .alarmTime(alarmTime)
+                .content((String) parsedResult.get("content"))
+                .scheduleType(ScheduleType.TO_DO)
+                .group(group)
+                .repeatWeek(new HashSet<>())
+                .createdBy(memberGroup)
+                .build();
+    }
+
     static public Schedule groupScheduleToEntity(
             GroupScheduleRequestDto.GroupScheduleAddRequestDto requestDto,
             Group group, ScheduleType scheduleType, MemberGroup memberGroup) {

--- a/src/main/java/com/example/ohmobackend/repository/RoutineRepository.java
+++ b/src/main/java/com/example/ohmobackend/repository/RoutineRepository.java
@@ -14,9 +14,9 @@ import java.util.Optional;
 
 public interface RoutineRepository extends JpaRepository<Routine, Long> {
 
-    @Query("SELECT r FROM Routine r " +
-            "JOIN FETCH r.schedule s " +
-            "JOIN FETCH s.memberCategory mc " +
+    @Query("SELECT r FROM MemberCategory mc " +
+            "JOIN mc.scheduleList s " +
+            "JOIN s.routineList r " +
             "WHERE mc.member = :member " +
             "AND r.date = :date")
     List<Routine> findRoutinesWithScheduleByMemberAndDate(
@@ -24,20 +24,20 @@ public interface RoutineRepository extends JpaRepository<Routine, Long> {
             @Param("date") LocalDate date
     );
 
-    @Query("SELECT DISTINCT r FROM Routine r " +
-            "JOIN FETCH r.schedule s " +
-            "WHERE r.date = :date " +
-            "AND s.group = :group")
+    @Query("SELECT r FROM Schedule s " +
+            "JOIN s.routineList r " +
+            "WHERE s.group = :group " +
+            "AND r.date = :date")
     List<Routine> findRoutinesWithScheduleByGroupAndDate(
             @Param("group") Group group,
             @Param("date") LocalDate date
     );
 
-    @Query("SELECT DISTINCT r FROM Routine r " +
-            "JOIN FETCH r.schedule s " +
-            "JOIN FETCH s.memberCategory mc " +
-            "WHERE r.date BETWEEN :startDate AND :endDate " +
-            "AND mc.member = :member")
+    @Query("SELECT r FROM MemberCategory mc " +
+            "JOIN mc.scheduleList s " +
+            "JOIN s.routineList r " +
+            "WHERE mc.member = :member " +
+            "AND r.date BETWEEN :startDate AND :endDate")
     List<Routine> findRoutinesByMemberAndDate(
             @Param("member") Member member,
             @Param("startDate") LocalDate startDate,
@@ -48,9 +48,10 @@ public interface RoutineRepository extends JpaRepository<Routine, Long> {
 
     List<Routine> findAllBySchedule(Schedule schedule);
 
-    @Query("SELECT r FROM Routine r " +
-            "JOIN FETCH r.schedule s " +
-            "WHERE s.group = :group AND r.date = :date")
+    @Query("SELECT r FROM Schedule s " +
+            "JOIN s.routineList r " +
+            "WHERE s.group = :group " +
+            "AND r.date = :date")
     List<Routine> findRoutinesWithScheduleAndAssignees(
             @Param("group") Group group,
             @Param("date") LocalDate date

--- a/src/main/java/com/example/ohmobackend/service/groupService/GroupCommandService.java
+++ b/src/main/java/com/example/ohmobackend/service/groupService/GroupCommandService.java
@@ -12,4 +12,5 @@ public interface GroupCommandService {
     public MemberGroupResponseDto.MemberGroupInfoDto updateNickname(Member member, GroupRequestDto.AddGroupNicknameDto requestDto);
     public void leaveGroup(Member member, GroupRequestDto.LeaveGroupRequestDto requestDto);
     public void transferManager(Member member, GroupRequestDto.TransferManagerRequestDto requestDto);
+    public void kickMember(Member member, GroupRequestDto.KickMemberRequestDto requestDto);
 }

--- a/src/main/java/com/example/ohmobackend/service/groupService/GroupCommandServiceImpl.java
+++ b/src/main/java/com/example/ohmobackend/service/groupService/GroupCommandServiceImpl.java
@@ -84,6 +84,27 @@ public class GroupCommandServiceImpl implements GroupCommandService {
 
     @Override
     @Transactional
+    public void kickMember(Member member, GroupRequestDto.KickMemberRequestDto requestDto) {
+        Group group = groupRepository.findById(requestDto.getGroupId())
+                .orElseThrow(() -> new GroupHandler(ErrorStatus.GROUP_NOT_FOUND));
+
+        MemberGroup requester = groupValidator.validateMemberGroup(member, group);
+        if (requester.getRole() != GroupRole.MANAGER) {
+            throw new GroupHandler(ErrorStatus.GROUP_NOT_MANAGER);
+        }
+
+        MemberGroup targetMemberGroup = memberGroupRepository.findById(requestDto.getTargetMemberGroupId())
+                .orElseThrow(() -> new GroupHandler(ErrorStatus.MEMBER_GROUP_NOT_FOUND));
+
+        if (targetMemberGroup.getRole() == GroupRole.MANAGER) {
+            throw new GroupHandler(ErrorStatus.GROUP_CANNOT_KICK_MANAGER);
+        }
+
+        memberGroupRepository.delete(targetMemberGroup);
+    }
+
+    @Override
+    @Transactional
     public void transferManager(Member member, GroupRequestDto.TransferManagerRequestDto requestDto) {
         Group group = groupRepository.findById(requestDto.getGroupId())
                 .orElseThrow(() -> new GroupHandler(ErrorStatus.GROUP_NOT_FOUND));

--- a/src/main/java/com/example/ohmobackend/service/scheduleService/GroupScheduleCommandService.java
+++ b/src/main/java/com/example/ohmobackend/service/scheduleService/GroupScheduleCommandService.java
@@ -12,6 +12,8 @@ public interface GroupScheduleCommandService {
 
     TodoResponseDto.TodoDto addGroupTodo(GroupScheduleRequestDto.GroupScheduleAddRequestDto request, Member member);
 
+    TodoResponseDto.TodoDto nlpAddGroupTodo(GroupScheduleRequestDto.GroupNlpAddRequestDto request, Member member);
+
     TodoResponseDto.TodoDto updateGroupTodo(Long todoId, GroupScheduleRequestDto.GroupTodoUpdateRequestDto request, Member member);
 
     void deleteGroupTodo(Long todoId, Member member);

--- a/src/main/java/com/example/ohmobackend/service/scheduleService/GroupScheduleCommandServiceImpl.java
+++ b/src/main/java/com/example/ohmobackend/service/scheduleService/GroupScheduleCommandServiceImpl.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -37,6 +38,7 @@ public class GroupScheduleCommandServiceImpl implements GroupScheduleCommandServ
     final private MemberGroupRepository memberGroupRepository;
     final private ScheduleRepository scheduleRepository;
     final private ApplicationEventPublisher eventPublisher;
+    final private NlpApiClient nlpApiClient;
 
     public List<RoutineResponseDto.RoutineDto> addGroupRoutine(GroupScheduleRequestDto.GroupScheduleAddRequestDto request, Member member) {
         Group group = groupScheduleQueryService.getGroup(request.getGroupId());
@@ -61,6 +63,19 @@ public class GroupScheduleCommandServiceImpl implements GroupScheduleCommandServ
         return routineList.stream()
                 .map(RoutineConverter::toRoutineDto)
                 .collect(Collectors.toList());
+    }
+
+    public TodoResponseDto.TodoDto nlpAddGroupTodo(GroupScheduleRequestDto.GroupNlpAddRequestDto request, Member member) {
+        Group group = groupScheduleQueryService.getGroup(request.getGroupId());
+        MemberGroup memberGroup = validateMemberGroup(member, group);
+
+        Map<String, Object> parsedResult = nlpApiClient.extractSchedule(request.getText());
+        Schedule schedule = ScheduleConverter.parsedResultToGroupScheduleEntity(parsedResult, group, memberGroup);
+        scheduleRepository.save(schedule);
+        Todo todo = todoRepository.save(TodoConverter.toEntity(schedule));
+
+        eventPublisher.publishEvent(new ScheduleChangeEvent(group.getId(), schedule.getDate(), ScheduleEventType.TODO_CREATED));
+        return TodoConverter.toTodoDto(todo);
     }
 
     public TodoResponseDto.TodoDto addGroupTodo(GroupScheduleRequestDto.GroupScheduleAddRequestDto request, Member member) {

--- a/src/main/java/com/example/ohmobackend/service/scheduleService/NlpApiClient.java
+++ b/src/main/java/com/example/ohmobackend/service/scheduleService/NlpApiClient.java
@@ -2,8 +2,8 @@ package com.example.ohmobackend.service.scheduleService;
 
 import com.example.ohmobackend.apiPayload.code.status.ErrorStatus;
 import com.example.ohmobackend.apiPayload.exception.handler.ScheduleHandler;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -26,8 +26,11 @@ public class NlpApiClient {
     @Value("${nlp.api-url}")
     private String nlpApiUrl;
 
-    public NlpApiClient(@Qualifier("nlpRestTemplate") RestTemplate nlpRestTemplate) {
+    public NlpApiClient(
+            @Qualifier("nlpRestTemplate") RestTemplate nlpRestTemplate,
+            CircuitBreakerRegistry circuitBreakerRegistry) {
         this.nlpRestTemplate = nlpRestTemplate;
+        registerLifecycleListeners(circuitBreakerRegistry);
     }
 
     @CircuitBreaker(name = "nlpApi", fallbackMethod = "fallback")
@@ -46,11 +49,30 @@ public class NlpApiClient {
         return (Map<String, Object>) response.getBody().get("result");
     }
 
+    // 서킷 상태 전환 시 로그로 생명주기 추적
+    private void registerLifecycleListeners(CircuitBreakerRegistry registry) {
+        registry.circuitBreaker("nlpApi")
+                .getEventPublisher()
+                .onStateTransition(event -> log.warn(
+                        "[CircuitBreaker] OpenAI API 서킷 상태 전환: {} → {}",
+                        event.getStateTransition().getFromState(),
+                        event.getStateTransition().getToState()
+                ))
+                .onCallNotPermitted(event ->
+                        log.error("[CircuitBreaker] OpenAI API 서킷 OPEN — 요청 차단됨")
+                );
+    }
+
     private Map<String, Object> fallback(String text, Exception e) {
-        log.error("NLP API 호출 실패: {}", e.getMessage());
+        log.error("[CircuitBreaker] OpenAI API 호출 실패: {}", e.getMessage());
+        if (e instanceof io.github.resilience4j.circuitbreaker.CallNotPermittedException) {
+            // 서킷이 OPEN 상태 — OpenAI 서버 장애로 판단하여 차단 중
+            throw new ScheduleHandler(ErrorStatus.NLP_SERVER_UNAVAILABLE);
+        }
         if (e instanceof ResourceAccessException) {
+            // 타임아웃 — OpenAI 응답 지연
             throw new ScheduleHandler(ErrorStatus.NLP_SERVER_TIMEOUT);
         }
-        throw new ScheduleHandler(ErrorStatus.NLP_SERVER_UNAVAILABLE);
+        throw new ScheduleHandler(ErrorStatus.NLP_PARSE_FAILED);
     }
 }

--- a/src/main/java/com/example/ohmobackend/web/controller/GroupController.java
+++ b/src/main/java/com/example/ohmobackend/web/controller/GroupController.java
@@ -80,6 +80,13 @@ public class GroupController {
         return ApiResponse.onSuccess(SuccessStatus.GROUP_LEAVE_OK, null);
     }
 
+    @DeleteMapping("/kick")
+    @Operation(summary = "그룹 멤버 강퇴 API", description = "방장이 특정 멤버를 그룹에서 강퇴합니다.")
+    public ApiResponse<Object> kickMember(@AuthUser Member member, @RequestBody GroupRequestDto.KickMemberRequestDto request) {
+        groupCommandService.kickMember(member, request);
+        return ApiResponse.onSuccess(SuccessStatus.GROUP_KICK_MEMBER_OK, null);
+    }
+
     @PatchMapping("/manager")
     @Operation(summary = "방장 넘기기 API", description = "현재 방장이 다른 멤버에게 방장을 넘깁니다.")
     public ApiResponse<Object> transferManager(@AuthUser Member member, @RequestBody GroupRequestDto.TransferManagerRequestDto request) {

--- a/src/main/java/com/example/ohmobackend/web/controller/GroupScheduleController.java
+++ b/src/main/java/com/example/ohmobackend/web/controller/GroupScheduleController.java
@@ -46,6 +46,16 @@ public class GroupScheduleController {
         return ApiResponse.onSuccess(SuccessStatus.SCHEDULE_TO_DO_OK, todoDto);
     }
 
+    @PostMapping("/nlp/todo")
+    @Operation(summary = "그룹 투두 AI 일정 등록 API",
+            description = "그룹 투두 AI 일정 등록 API입니다. 입력 필수 요소: groupId, text")
+    public ApiResponse<TodoResponseDto.TodoDto> nlpAddGroupTodo(
+            @RequestBody GroupScheduleRequestDto.GroupNlpAddRequestDto request,
+            @AuthUser Member member) {
+        TodoResponseDto.TodoDto todoDto = groupScheduleCommandService.nlpAddGroupTodo(request, member);
+        return ApiResponse.onSuccess(SuccessStatus.SCHEDULE_TO_DO_OK, todoDto);
+    }
+
     @PostMapping("/assignee-todo")
     @Operation(summary = "그룹 투두 일정 담당자 등록 API", description = "그룹 투두 일정 담당자 등록 API 입니다.")
     public ApiResponse<Object> addTodoScheduleAssignee(@RequestBody GroupScheduleRequestDto.TodoScheduleAssigneeRequestDto request, @AuthUser Member member) {

--- a/src/main/java/com/example/ohmobackend/web/dto/groupDto/GroupRequestDto.java
+++ b/src/main/java/com/example/ohmobackend/web/dto/groupDto/GroupRequestDto.java
@@ -65,4 +65,14 @@ public class GroupRequestDto {
         private Long targetMemberGroupId;
     }
 
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class KickMemberRequestDto {
+        private Long groupId;
+        private Long targetMemberGroupId;
+    }
+
 }

--- a/src/main/java/com/example/ohmobackend/web/dto/groupScheduleDto/GroupScheduleRequestDto.java
+++ b/src/main/java/com/example/ohmobackend/web/dto/groupScheduleDto/GroupScheduleRequestDto.java
@@ -35,6 +35,12 @@ public class GroupScheduleRequestDto {
     }
 
     @Getter
+    public static class GroupNlpAddRequestDto {
+        private Long groupId;
+        private String text;
+    }
+
+    @Getter
     public static class TodoScheduleAssigneeRequestDto {
         private Long todoId;
         private Long memberGroupId;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,12 +60,16 @@ resilience4j:
     instances:
       nlpApi:
         registerHealthIndicator: true
+        slidingWindowType: COUNT_BASED
         slidingWindowSize: 10
-        failureRateThreshold: 50
-        waitDurationInOpenState: 30s
-        permittedNumberOfCallsInHalfOpenState: 3
+        failureRateThreshold: 40            # 일정 생성 쓰기 연산으로 사용자 임팩트가 크므로 기본값(50%)보다 엄격하게 설정
+        slowCallDurationThreshold: 5s       # OpenAI 응답 지연 감지 기준, read-timeout(10s)의 절반 초과 시 비정상으로 판단
+        slowCallRateThreshold: 50           # 지연 호출이 50% 이상이면 OpenAI 서버 과부하 상태로 판단
+        waitDurationInOpenState: 30s        # OpenAI 장애 시 불필요한 재시도 방지, 통상 수분 내 복구되므로 30초 간격으로 재시도
+        permittedNumberOfCallsInHalfOpenState: 2
         recordExceptions:
-          - org.springframework.web.client.ResourceAccessException
+          - org.springframework.web.client.ResourceAccessException  # 타임아웃/네트워크 오류
+          - org.springframework.web.client.HttpServerErrorException # OpenAI 5xx 오류
 
 management:
   endpoints:


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 그룹 강퇴 API
  - DELETE /api/group/kick 엔드포인트 추가
  - 방장만 강퇴 가능, 매니저(방장) 본인은 강퇴 불가
  - KickMemberRequestDto (groupId, targetMemberGroupId) 추가
  - GROUP_CANNOT_KICK_MANAGER 에러 코드 추가 (GROUP4007)

- 그룹 AI 투두 등록 API
  - POST /api/group-schedule/nlp/todo 엔드포인트 추가
  - NLP 서버로 텍스트 파싱 후 그룹 투두 자동 생성
  - GroupNlpAddRequestDto (groupId, text) 추가
  - ScheduleConverter에 parsedResultToGroupScheduleEntity 추가
  - 투두 생성 후 SSE TODO_CREATED 이벤트 발행

- routine 조회 쿼리 드라이빙 테이블 변경
 routine은 schedule 1개당 반복 요일 × 기간만큼 행이 생성되는 가장 큰 테이블로,           
  기존 쿼리는 routine을 드라이빙 테이블로 사용해 불필요하게 많은 행을 먼저 스캔했다.      
                                                                                          
  - member 기반 쿼리: MemberCategory → Schedule → Routine 방향으로 변경                   
    (mc.member 조건으로 수 건의 카테고리만 조회 후 조인)                                  
  - group 기반 쿼리: Schedule → Routine 방향으로 변경                                     
    (s.group 조건으로 해당 그룹 일정만 조회 후 조인)                                      
  - 드라이빙 테이블 변경으로 DISTINCT 불필요 → 제거                                       
  - 적용 대상: findRoutinesWithScheduleByMemberAndDate,                                   
  findRoutinesWithScheduleByGroupAndDate,                                                 
    findRoutinesByMemberAndDate, findRoutinesWithScheduleAndAssignees

## 📌 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 리뷰를 원하는 부분 등을 적어주세요! -->
- 내용

### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #이슈번호
