### PR TITLE
[FEAT] FCM 푸시 알림 기능 추가 및 그룹 초대 동시성 문제 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ out/
 
 ### mac OS ###
 .DS_Store
+
+### Firebase ###
+src/main/resources/firebase-service-account.json

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     testImplementation 'com.h2database:h2'
     implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
     implementation 'org.springframework.boot:spring-boot-starter-aop'
+    implementation 'com.google.firebase:firebase-admin:9.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/ohmobackend/OhMoBackendApplication.java
+++ b/src/main/java/com/example/ohmobackend/OhMoBackendApplication.java
@@ -3,9 +3,11 @@ package com.example.ohmobackend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class OhMoBackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/ohmobackend/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/example/ohmobackend/apiPayload/code/status/SuccessStatus.java
@@ -19,6 +19,7 @@ public enum SuccessStatus implements BaseCode {
     MEMBER_WITHDRAW_OK(HttpStatus.OK, "AUTH2004", "회원 탈퇴가 완료되었습니다."),
     PASSWORD_FIND_CODE_SENT(HttpStatus.OK, "AUTH2005", "인증 코드가 이메일로 발송되었습니다."),
     PASSWORD_RESET_OK(HttpStatus.OK, "AUTH2006", "비밀번호가 재설정되었습니다."),
+    FCM_TOKEN_UPDATE_OK(HttpStatus.OK, "AUTH2007", "FCM 토큰이 등록되었습니다."),
 
     // 카텍고리 관련 응답
     MEMBER_CATEGORY_REGISTER_OK(HttpStatus.OK, "CATEGORY2000", "카테고리 등록이 완료되었습니다."),

--- a/src/main/java/com/example/ohmobackend/domain/Member.java
+++ b/src/main/java/com/example/ohmobackend/domain/Member.java
@@ -36,6 +36,8 @@ public class Member extends BaseEntity {
     @Column(name = "profile_image_url")
     private String profileImageUrl;
 
+    private String fcmToken;
+
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<MemberCategory> userCategoryList = new ArrayList<>();
 
@@ -65,5 +67,9 @@ public class Member extends BaseEntity {
 
     public void updatePassword(String newPassword) {
         this.password = newPassword;
+    }
+
+    public void updateFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken;
     }
 }

--- a/src/main/java/com/example/ohmobackend/domain/MemberGroup.java
+++ b/src/main/java/com/example/ohmobackend/domain/MemberGroup.java
@@ -15,6 +15,9 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DynamicUpdate
+@Table(name = "member_group", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"member_id", "group_id"})
+})
 public class MemberGroup extends BaseEntity {
 
     @Id

--- a/src/main/java/com/example/ohmobackend/repository/GroupRepository.java
+++ b/src/main/java/com/example/ohmobackend/repository/GroupRepository.java
@@ -1,11 +1,19 @@
 package com.example.ohmobackend.repository;
 
 import com.example.ohmobackend.domain.Group;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
 
     public Optional<Group> findByGroupCode(String groupCode);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT g FROM Group g WHERE g.id = :id")
+    Optional<Group> findByIdWithLock(@Param("id") Long id);
 }

--- a/src/main/java/com/example/ohmobackend/repository/RoutineRepository.java
+++ b/src/main/java/com/example/ohmobackend/repository/RoutineRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import jakarta.persistence.LockModeType;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -66,4 +67,7 @@ public interface RoutineRepository extends JpaRepository<Routine, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT r FROM Routine r WHERE r.id = :id")
     Optional<Routine> findByIdWithLock(@Param("id") Long id);
+
+    @Query("SELECT r FROM Routine r JOIN FETCH r.schedule s WHERE s.alarmTime = :alarmTime AND r.date = :date AND s.group IS NOT NULL")
+    List<Routine> findGroupRoutinesWithAlarm(@Param("alarmTime") LocalTime alarmTime, @Param("date") LocalDate date);
 }

--- a/src/main/java/com/example/ohmobackend/repository/TodoRepository.java
+++ b/src/main/java/com/example/ohmobackend/repository/TodoRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.repository.query.Param;
 import jakarta.persistence.LockModeType;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -63,4 +64,7 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT t FROM Todo t WHERE t.id = :id")
     Optional<Todo> findByIdWithLock(@Param("id") Long id);
+
+    @Query("SELECT t FROM Todo t JOIN FETCH t.schedule s WHERE s.alarmTime = :alarmTime AND s.date = :date AND s.group IS NOT NULL")
+    List<Todo> findGroupTodosWithAlarm(@Param("alarmTime") LocalTime alarmTime, @Param("date") LocalDate date);
 }

--- a/src/main/java/com/example/ohmobackend/service/assigneeService/AssigneeCommandServiceImpl.java
+++ b/src/main/java/com/example/ohmobackend/service/assigneeService/AssigneeCommandServiceImpl.java
@@ -10,6 +10,7 @@ import com.example.ohmobackend.repository.MemberGroupRepository;
 import com.example.ohmobackend.repository.RoutineRepository;
 import com.example.ohmobackend.repository.ScheduleAssigneeRepository;
 import com.example.ohmobackend.repository.TodoRepository;
+import com.example.ohmobackend.service.FcmService;
 import com.example.ohmobackend.service.ScheduleChangeEvent;
 import com.example.ohmobackend.web.dto.groupScheduleDto.GroupScheduleRequestDto;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,7 @@ public class AssigneeCommandServiceImpl implements AssigneeCommandService {
     private final MemberGroupRepository memberGroupRepository;
     private final ScheduleAssigneeRepository scheduleAssigneeRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final FcmService fcmService;
 
     public void addTodoScheduleAssignee(GroupScheduleRequestDto.TodoScheduleAssigneeRequestDto requestDto, Member member) {
         Todo todo = todoRepository.findWithScheduleAndGroupById(requestDto.getTodoId())
@@ -51,6 +53,10 @@ public class AssigneeCommandServiceImpl implements AssigneeCommandService {
         ScheduleAssignee scheduleAssignee = ScheduleConverter.todoScheduleAssigneeToEntity(memberGroup, todo);
         scheduleAssigneeRepository.save(scheduleAssignee);
         eventPublisher.publishEvent(new ScheduleChangeEvent(group.getId(), todo.getDate(), ScheduleEventType.TODO_ASSIGNEE_UPDATED));
+
+        fcmService.sendNotification(memberGroup.getMember().getFcmToken(),
+                "담당자로 지정됐어요",
+                group.getGroupName() + "의 " + schedule.getContent() + " 일정 담당자로 지정됐습니다.");
     }
 
     public void addRoutineScheduleAssignee(GroupScheduleRequestDto.RoutineScheduleAssigneeRequestDto requestDto, Member member) {
@@ -75,6 +81,10 @@ public class AssigneeCommandServiceImpl implements AssigneeCommandService {
         ScheduleAssignee scheduleAssignee = ScheduleConverter.routineScheduleAssigneeToEntity(memberGroup, routine);
         scheduleAssigneeRepository.save(scheduleAssignee);
         eventPublisher.publishEvent(new ScheduleChangeEvent(group.getId(), routine.getDate(), ScheduleEventType.ROUTINE_ASSIGNEE_UPDATED));
+
+        fcmService.sendNotification(memberGroup.getMember().getFcmToken(),
+                "담당자로 지정됐어요",
+                group.getGroupName() + "의 " + schedule.getContent() + " 일정 담당자로 지정됐습니다.");
     }
 
     public void updateAssigneeStatus(Long assigneeId, Member member) {

--- a/src/main/java/com/example/ohmobackend/service/groupService/GroupCommandServiceImpl.java
+++ b/src/main/java/com/example/ohmobackend/service/groupService/GroupCommandServiceImpl.java
@@ -12,6 +12,7 @@ import com.example.ohmobackend.domain.enums.GroupRole;
 import com.example.ohmobackend.repository.GroupRepository;
 import com.example.ohmobackend.repository.MemberGroupRepository;
 import com.example.ohmobackend.repository.MemberRepository;
+import com.example.ohmobackend.service.FcmService;
 import com.example.ohmobackend.web.dto.groupDto.GroupRequestDto;
 import com.example.ohmobackend.web.dto.groupDto.GroupResponseDto;
 import com.example.ohmobackend.web.dto.memberGroupDto.MemberGroupResponseDto;
@@ -29,6 +30,7 @@ public class GroupCommandServiceImpl implements GroupCommandService {
     final MemberGroupRepository memberGroupRepository;
     final MemberRepository memberRepository;
     final GroupValidator groupValidator;
+    final FcmService fcmService;
 
     @Override
     public GroupResponseDto.GroupDto addGroup(Member member, GroupRequestDto.AddGroupRequestDto requestDto) {
@@ -127,7 +129,7 @@ public class GroupCommandServiceImpl implements GroupCommandService {
     @Override
     @Transactional
     public void inviteMember(Member member, GroupRequestDto.InviteMemberRequestDto requestDto) {
-        Group group = groupRepository.findById(requestDto.getGroupId())
+        Group group = groupRepository.findByIdWithLock(requestDto.getGroupId())
                 .orElseThrow(() -> new GroupHandler(ErrorStatus.GROUP_NOT_FOUND));
 
         MemberGroup requester = groupValidator.validateMemberGroup(member, group);
@@ -143,5 +145,9 @@ public class GroupCommandServiceImpl implements GroupCommandService {
 
         MemberGroup newMemberGroup = MemberGroupConverter.toMemberGroupEntity(targetMember, group, GroupRole.MEMBER);
         memberGroupRepository.save(newMemberGroup);
+
+        fcmService.sendNotification(targetMember.getFcmToken(),
+                "그룹에 초대됐어요",
+                group.getGroupName() + " 그룹에 초대됐습니다.");
     }
 }

--- a/src/main/java/com/example/ohmobackend/service/memberService/MemberCommandService.java
+++ b/src/main/java/com/example/ohmobackend/service/memberService/MemberCommandService.java
@@ -12,4 +12,5 @@ public interface MemberCommandService {
     public void updatePassword(Member member, MemberRequestDto.UpdatePasswordDto request);
     public void deleteMemberProfileImageFromS3(Member member);
     public String uploadProfileImageToS3(MultipartFile profileImage, String email);
+    public void updateFcmToken(Member member, String fcmToken);
 }

--- a/src/main/java/com/example/ohmobackend/service/memberService/MemberCommandServiceImpl.java
+++ b/src/main/java/com/example/ohmobackend/service/memberService/MemberCommandServiceImpl.java
@@ -96,4 +96,9 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         String fileName = "profile/" + email + "_" + System.currentTimeMillis();
         return fileUploadService.upload(profileImage, fileName);
     }
+
+    @Override
+    public void updateFcmToken(Member member, String fcmToken) {
+        member.updateFcmToken(fcmToken);
+    }
 }

--- a/src/main/java/com/example/ohmobackend/service/noticeService/NoticeCommandServiceImpl.java
+++ b/src/main/java/com/example/ohmobackend/service/noticeService/NoticeCommandServiceImpl.java
@@ -9,12 +9,16 @@ import com.example.ohmobackend.domain.Notice;
 import com.example.ohmobackend.repository.GroupRepository;
 import com.example.ohmobackend.repository.MemberGroupRepository;
 import com.example.ohmobackend.repository.NoticeRepository;
+import com.example.ohmobackend.service.FcmService;
 import com.example.ohmobackend.web.dto.noticeDto.NoticeRequestDto;
 import com.example.ohmobackend.web.dto.noticeDto.NoticeResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +27,7 @@ public class NoticeCommandServiceImpl implements NoticeCommandService {
     private final GroupRepository groupRepository;
     private final NoticeRepository noticeRepository;
     private final MemberGroupRepository memberGroupRepository;
+    private final FcmService fcmService;
 
     @CacheEvict(value = "noticesByMonth", allEntries = true)
     public NoticeResponseDto.NoticeDto addNotice(NoticeRequestDto.AddNoticeDto requestDto, Member member) {
@@ -33,6 +38,14 @@ public class NoticeCommandServiceImpl implements NoticeCommandService {
 
         Notice notice = NoticeConverter.toNoticeEntity(requestDto, group);
         noticeRepository.save(notice);
+
+        String noticeBody = notice.getNotice().length() > 50
+                ? notice.getNotice().substring(0, 50) : notice.getNotice();
+        List<String> tokens = memberGroupRepository.findAllByGroup(group).stream()
+                .filter(mg -> !mg.getMember().getId().equals(member.getId()))
+                .map(mg -> mg.getMember().getFcmToken())
+                .collect(Collectors.toList());
+        fcmService.sendNotifications(tokens, group.getGroupName() + " 공지사항", noticeBody);
 
         NoticeResponseDto.NoticeDto noticeDto = NoticeConverter.toNoticeDto(notice);
         return noticeDto;

--- a/src/main/java/com/example/ohmobackend/service/scheduleService/GroupScheduleCommandServiceImpl.java
+++ b/src/main/java/com/example/ohmobackend/service/scheduleService/GroupScheduleCommandServiceImpl.java
@@ -9,6 +9,7 @@ import com.example.ohmobackend.converter.TodoConverter;
 import com.example.ohmobackend.domain.*;
 import com.example.ohmobackend.domain.enums.ScheduleType;
 import com.example.ohmobackend.repository.*;
+import com.example.ohmobackend.service.FcmService;
 import com.example.ohmobackend.service.ScheduleChangeEvent;
 import com.example.ohmobackend.web.dto.groupScheduleDto.GroupScheduleRequestDto;
 import com.example.ohmobackend.web.dto.routineDto.RoutineResponseDto;
@@ -39,6 +40,7 @@ public class GroupScheduleCommandServiceImpl implements GroupScheduleCommandServ
     final private ScheduleRepository scheduleRepository;
     final private ApplicationEventPublisher eventPublisher;
     final private NlpApiClient nlpApiClient;
+    final private FcmService fcmService;
 
     public List<RoutineResponseDto.RoutineDto> addGroupRoutine(GroupScheduleRequestDto.GroupScheduleAddRequestDto request, Member member) {
         Group group = groupScheduleQueryService.getGroup(request.getGroupId());
@@ -60,6 +62,14 @@ public class GroupScheduleCommandServiceImpl implements GroupScheduleCommandServ
         routineRepository.saveAll(routineList);
 
         eventPublisher.publishEvent(new ScheduleChangeEvent(group.getId(), request.getDate(), ScheduleEventType.ROUTINE_CREATED));
+
+        List<String> tokens = memberGroupRepository.findAllByGroup(group).stream()
+                .filter(mg -> !mg.getMember().getId().equals(member.getId()))
+                .map(mg -> mg.getMember().getFcmToken())
+                .collect(Collectors.toList());
+        fcmService.sendNotifications(tokens, "새 일정이 추가됐어요",
+                group.getGroupName() + "에 " + schedule.getContent() + " 일정이 추가됐습니다.");
+
         return routineList.stream()
                 .map(RoutineConverter::toRoutineDto)
                 .collect(Collectors.toList());
@@ -75,6 +85,14 @@ public class GroupScheduleCommandServiceImpl implements GroupScheduleCommandServ
         Todo todo = todoRepository.save(TodoConverter.toEntity(schedule));
 
         eventPublisher.publishEvent(new ScheduleChangeEvent(group.getId(), schedule.getDate(), ScheduleEventType.TODO_CREATED));
+
+        List<String> tokens = memberGroupRepository.findAllByGroup(group).stream()
+                .filter(mg -> !mg.getMember().getId().equals(member.getId()))
+                .map(mg -> mg.getMember().getFcmToken())
+                .collect(Collectors.toList());
+        fcmService.sendNotifications(tokens, "새 일정이 추가됐어요",
+                group.getGroupName() + "에 " + schedule.getContent() + " 일정이 추가됐습니다.");
+
         return TodoConverter.toTodoDto(todo);
     }
 
@@ -88,6 +106,14 @@ public class GroupScheduleCommandServiceImpl implements GroupScheduleCommandServ
         scheduleRepository.save(schedule);
         Todo todo = todoRepository.save(TodoConverter.toEntity(schedule));
         eventPublisher.publishEvent(new ScheduleChangeEvent(group.getId(), request.getDate(), ScheduleEventType.TODO_CREATED));
+
+        List<String> tokens = memberGroupRepository.findAllByGroup(group).stream()
+                .filter(mg -> !mg.getMember().getId().equals(member.getId()))
+                .map(mg -> mg.getMember().getFcmToken())
+                .collect(Collectors.toList());
+        fcmService.sendNotifications(tokens, "새 일정이 추가됐어요",
+                group.getGroupName() + "에 " + schedule.getContent() + " 일정이 추가됐습니다.");
+
         return TodoConverter.toTodoDto(todo);
     }
 

--- a/src/main/java/com/example/ohmobackend/web/controller/GroupController.java
+++ b/src/main/java/com/example/ohmobackend/web/controller/GroupController.java
@@ -12,6 +12,7 @@ import com.example.ohmobackend.web.dto.groupDto.GroupResponseDto;
 import com.example.ohmobackend.web.dto.memberGroupDto.MemberGroupResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -96,7 +97,7 @@ public class GroupController {
 
     @PostMapping("/invite")
     @Operation(summary = "멤버 초대 API", description = "방장이 멤버 ID로 특정 멤버를 그룹에 초대합니다.")
-    public ApiResponse<Object> inviteMember(@AuthUser Member member, @RequestBody GroupRequestDto.InviteMemberRequestDto request) {
+    public ApiResponse<Object> inviteMember(@AuthUser Member member, @Valid @RequestBody GroupRequestDto.InviteMemberRequestDto request) {
         groupCommandService.inviteMember(member, request);
         return ApiResponse.onSuccess(SuccessStatus.GROUP_INVITE_MEMBER_OK, null);
     }

--- a/src/main/java/com/example/ohmobackend/web/controller/MemberController.java
+++ b/src/main/java/com/example/ohmobackend/web/controller/MemberController.java
@@ -114,4 +114,12 @@ public class MemberController {
         authService.resetPassword(request);
         return ApiResponse.onSuccess(SuccessStatus.PASSWORD_RESET_OK, null);
     }
+
+    @PatchMapping("/fcm-token")
+    @Operation(summary = "FCM 토큰 등록 API", description = "푸시 알림을 위한 FCM 토큰을 등록합니다.")
+    public ApiResponse<Void> updateFcmToken(@AuthUser Member member,
+                                             @RequestBody MemberRequestDto.UpdateFcmTokenRequestDto request) {
+        memberCommandService.updateFcmToken(member, request.getFcmToken());
+        return ApiResponse.onSuccess(SuccessStatus.FCM_TOKEN_UPDATE_OK, null);
+    }
 }

--- a/src/main/java/com/example/ohmobackend/web/dto/groupDto/GroupRequestDto.java
+++ b/src/main/java/com/example/ohmobackend/web/dto/groupDto/GroupRequestDto.java
@@ -1,5 +1,6 @@
 package com.example.ohmobackend.web.dto.groupDto;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 public class GroupRequestDto {
@@ -81,7 +82,9 @@ public class GroupRequestDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class InviteMemberRequestDto {
+        @NotNull
         private Long groupId;
+        @NotNull
         private Long targetMemberId;
     }
 

--- a/src/main/java/com/example/ohmobackend/web/dto/memberDto/MemberRequestDto.java
+++ b/src/main/java/com/example/ohmobackend/web/dto/memberDto/MemberRequestDto.java
@@ -44,4 +44,9 @@ public class MemberRequestDto {
         private String code;
         private String newPassword;
     }
+
+    @Getter
+    public static class UpdateFcmTokenRequestDto {
+        private String fcmToken;
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -86,6 +86,9 @@ management:
       slo:
         http.server.requests: 100ms, 200ms, 300ms, 400ms, 500ms, 600ms, 800ms, 1s
 
+firebase:
+  service-account-path: classpath:firebase-service-account.json
+
 cloud:
   aws:
     s3:


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
  - Firebase Admin SDK 연동 및 FcmService 구현                                                    
  - 이벤트별 FCM 알림 트리거 추가
    - 그룹 일정(Todo/Routine) 생성 시 그룹 멤버 전체 알림                                         
    - 담당자 지정 시 해당 멤버 알림                                                               
    - 공지사항 등록 시 그룹 멤버 전체 알림                                                        
    - 그룹 초대 시 초대받은 멤버 알림                                                             
  - 매 분 실행되는 알람 스케줄러 추가 (AlarmSchedulerService)                                     
  - FCM 토큰 등록 API 추가 (PATCH /api/member/fcm-token)                                          
  - 그룹 초대 동시성 문제 개선                                                                    
    - MemberGroup에 UniqueConstraint(member_id, group_id) 추가                                    
    - SERIALIZABLE → PESSIMISTIC_WRITE 방식으로 변경                                              
  - InviteMemberRequestDto 필드 @NotNull 검증 추가 
## 📌 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 리뷰를 원하는 부분 등을 적어주세요! -->
- 내용

### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #이슈번호


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added push notification support for group invitations, schedule assignments, notices, and new schedules
  * Added endpoint for users to register and update their device tokens for notifications

* **Improvements**
  * Enhanced validation for group invitation requests
  * Added database constraints to prevent duplicate group memberships
  * Enabled scheduling capabilities for the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->