### PR TITLE
[FEAT]: 그룹 초대 방식 이메일 기반으로 변경 및 초대 수락/거절 API 추가

### DIFF
--- a/src/main/java/com/example/ohmobackend/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/ohmobackend/apiPayload/code/status/ErrorStatus.java
@@ -64,6 +64,8 @@ public enum ErrorStatus implements BaseErrorCode {
     GROUP_MANAGER_CANNOT_LEAVE(HttpStatus.BAD_REQUEST, "GROUP4005", "그룹 매니저는 다른 멤버가 있을 경우 그룹을 나갈 수 없습니다."),
     GROUP_NOT_MANAGER(HttpStatus.BAD_REQUEST, "GROUP4006", "그룹 매니저만 방장을 넘길 수 있습니다."),
     GROUP_CANNOT_KICK_MANAGER(HttpStatus.BAD_REQUEST, "GROUP4007", "매니저는 강퇴할 수 없습니다."),
+    GROUP_INVITATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "GROUP4008", "초대를 찾을 수 없습니다."),
+    GROUP_ALREADY_INVITED(HttpStatus.BAD_REQUEST, "GROUP4009", "이미 초대된 멤버입니다."),
 
     // 루틴
     ROUTINE_NOT_FOUND(HttpStatus.BAD_REQUEST, "ROUTINE4001", "루틴을 찾을 수 없습니다."),

--- a/src/main/java/com/example/ohmobackend/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/example/ohmobackend/apiPayload/code/status/SuccessStatus.java
@@ -65,6 +65,9 @@ public enum SuccessStatus implements BaseCode {
     GROUP_TRANSFER_MANAGER_OK(HttpStatus.OK, "GROUP_2007", "방장 넘기기가 완료되었습니다."),
     GROUP_KICK_MEMBER_OK(HttpStatus.OK, "GROUP_2008", "그룹 멤버 강퇴가 완료되었습니다."),
     GROUP_INVITE_MEMBER_OK(HttpStatus.OK, "GROUP_2009", "그룹 멤버 초대가 완료되었습니다."),
+    GROUP_INVITATION_LIST_OK(HttpStatus.OK, "GROUP_2010", "초대 목록 조회가 완료되었습니다."),
+    GROUP_INVITATION_ACCEPT_OK(HttpStatus.OK, "GROUP_2011", "그룹 초대를 수락했습니다."),
+    GROUP_INVITATION_REJECT_OK(HttpStatus.OK, "GROUP_2012", "그룹 초대를 거절했습니다."),
 
     // 공지사항 관련
     GROUP_NOTICE_REGISTER_OK(HttpStatus.OK, "GROUP_2001", "그룹 공지사항 등록이 완료되었습니다."),

--- a/src/main/java/com/example/ohmobackend/domain/GroupInvitation.java
+++ b/src/main/java/com/example/ohmobackend/domain/GroupInvitation.java
@@ -1,0 +1,31 @@
+package com.example.ohmobackend.domain;
+
+import com.example.ohmobackend.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "group_invitation")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GroupInvitation extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "invitation_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id", nullable = false)
+    private Group group;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "invited_member_id", nullable = false)
+    private Member invitedMember;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "invited_by_id", nullable = false)
+    private Member invitedBy;
+}

--- a/src/main/java/com/example/ohmobackend/domain/enums/FcmNotificationType.java
+++ b/src/main/java/com/example/ohmobackend/domain/enums/FcmNotificationType.java
@@ -1,0 +1,9 @@
+package com.example.ohmobackend.domain.enums;
+
+public enum FcmNotificationType {
+    GROUP_INVITATION,
+    SCHEDULE_ADDED,
+    ASSIGNEE_ADDED,
+    NOTICE,
+    SCHEDULE_ALARM
+}

--- a/src/main/java/com/example/ohmobackend/repository/GroupInvitationRepository.java
+++ b/src/main/java/com/example/ohmobackend/repository/GroupInvitationRepository.java
@@ -1,0 +1,13 @@
+package com.example.ohmobackend.repository;
+
+import com.example.ohmobackend.domain.Group;
+import com.example.ohmobackend.domain.GroupInvitation;
+import com.example.ohmobackend.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface GroupInvitationRepository extends JpaRepository<GroupInvitation, Long> {
+    List<GroupInvitation> findAllByInvitedMember(Member invitedMember);
+    boolean existsByGroupAndInvitedMember(Group group, Member invitedMember);
+}

--- a/src/main/java/com/example/ohmobackend/service/FcmService.java
+++ b/src/main/java/com/example/ohmobackend/service/FcmService.java
@@ -1,5 +1,6 @@
 package com.example.ohmobackend.service;
 
+import com.example.ohmobackend.domain.enums.FcmNotificationType;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.Message;
@@ -13,7 +14,7 @@ import java.util.List;
 @Service
 public class FcmService {
 
-    public void sendNotification(String fcmToken, String title, String body) {
+    public void sendNotification(String fcmToken, String title, String body, FcmNotificationType type) {
         if (fcmToken == null || fcmToken.isBlank()) {
             return;
         }
@@ -28,6 +29,7 @@ public class FcmService {
                             .setTitle(title)
                             .setBody(body)
                             .build())
+                    .putData("type", type.name())
                     .build();
             FirebaseMessaging.getInstance().send(message);
         } catch (Exception e) {
@@ -35,12 +37,36 @@ public class FcmService {
         }
     }
 
-    public void sendNotifications(List<String> fcmTokens, String title, String body) {
+    public void sendInvitationNotification(String fcmToken, String groupName, Long invitationId) {
+        if (fcmToken == null || fcmToken.isBlank()) {
+            return;
+        }
+        if (FirebaseApp.getApps().isEmpty()) {
+            log.warn("Firebase not initialized. Skipping FCM notification.");
+            return;
+        }
+        try {
+            Message message = Message.builder()
+                    .setToken(fcmToken)
+                    .setNotification(Notification.builder()
+                            .setTitle("그룹에 초대됐어요")
+                            .setBody(groupName + " 그룹에 초대됐습니다.")
+                            .build())
+                    .putData("type", FcmNotificationType.GROUP_INVITATION.name())
+                    .putData("invitationId", String.valueOf(invitationId))
+                    .build();
+            FirebaseMessaging.getInstance().send(message);
+        } catch (Exception e) {
+            log.warn("FCM invitation notification failed for token {}: {}", fcmToken, e.getMessage());
+        }
+    }
+
+    public void sendNotifications(List<String> fcmTokens, String title, String body, FcmNotificationType type) {
         if (fcmTokens == null || fcmTokens.isEmpty()) {
             return;
         }
         fcmTokens.stream()
                 .filter(token -> token != null && !token.isBlank())
-                .forEach(token -> sendNotification(token, title, body));
+                .forEach(token -> sendNotification(token, title, body, type));
     }
 }

--- a/src/main/java/com/example/ohmobackend/service/groupService/GroupCommandService.java
+++ b/src/main/java/com/example/ohmobackend/service/groupService/GroupCommandService.java
@@ -14,4 +14,6 @@ public interface GroupCommandService {
     public void transferManager(Member member, GroupRequestDto.TransferManagerRequestDto requestDto);
     public void kickMember(Member member, GroupRequestDto.KickMemberRequestDto requestDto);
     public void inviteMember(Member member, GroupRequestDto.InviteMemberRequestDto requestDto);
+    public void acceptInvitation(Member member, GroupRequestDto.InvitationActionRequestDto requestDto);
+    public void rejectInvitation(Member member, GroupRequestDto.InvitationActionRequestDto requestDto);
 }

--- a/src/main/java/com/example/ohmobackend/service/groupService/GroupCommandServiceImpl.java
+++ b/src/main/java/com/example/ohmobackend/service/groupService/GroupCommandServiceImpl.java
@@ -6,9 +6,11 @@ import com.example.ohmobackend.apiPayload.exception.handler.MemberHandler;
 import com.example.ohmobackend.converter.GroupConverter;
 import com.example.ohmobackend.converter.MemberGroupConverter;
 import com.example.ohmobackend.domain.Group;
+import com.example.ohmobackend.domain.GroupInvitation;
 import com.example.ohmobackend.domain.Member;
 import com.example.ohmobackend.domain.MemberGroup;
 import com.example.ohmobackend.domain.enums.GroupRole;
+import com.example.ohmobackend.repository.GroupInvitationRepository;
 import com.example.ohmobackend.repository.GroupRepository;
 import com.example.ohmobackend.repository.MemberGroupRepository;
 import com.example.ohmobackend.repository.MemberRepository;
@@ -29,6 +31,7 @@ public class GroupCommandServiceImpl implements GroupCommandService {
     final GroupRepository groupRepository;
     final MemberGroupRepository memberGroupRepository;
     final MemberRepository memberRepository;
+    final GroupInvitationRepository groupInvitationRepository;
     final GroupValidator groupValidator;
     final FcmService fcmService;
 
@@ -137,17 +140,55 @@ public class GroupCommandServiceImpl implements GroupCommandService {
             throw new GroupHandler(ErrorStatus.GROUP_NOT_MANAGER);
         }
 
-        Member targetMember = memberRepository.findById(requestDto.getTargetMemberId())
+        Member targetMember = memberRepository.findByEmail(requestDto.getTargetEmail())
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
         groupValidator.validateExistMember(targetMember, group);
         groupValidator.validateGroupCount(group);
 
-        MemberGroup newMemberGroup = MemberGroupConverter.toMemberGroupEntity(targetMember, group, GroupRole.MEMBER);
-        memberGroupRepository.save(newMemberGroup);
+        if (groupInvitationRepository.existsByGroupAndInvitedMember(group, targetMember)) {
+            throw new GroupHandler(ErrorStatus.GROUP_ALREADY_INVITED);
+        }
 
-        fcmService.sendNotification(targetMember.getFcmToken(),
-                "그룹에 초대됐어요",
-                group.getGroupName() + " 그룹에 초대됐습니다.");
+        GroupInvitation invitation = GroupInvitation.builder()
+                .group(group)
+                .invitedMember(targetMember)
+                .invitedBy(member)
+                .build();
+        GroupInvitation savedInvitation = groupInvitationRepository.save(invitation);
+
+        fcmService.sendInvitationNotification(targetMember.getFcmToken(), group.getGroupName(), savedInvitation.getId());
+    }
+
+    @Override
+    @Transactional
+    public void acceptInvitation(Member member, GroupRequestDto.InvitationActionRequestDto requestDto) {
+        GroupInvitation invitation = groupInvitationRepository.findById(requestDto.getInvitationId())
+                .orElseThrow(() -> new GroupHandler(ErrorStatus.GROUP_INVITATION_NOT_FOUND));
+
+        if (!invitation.getInvitedMember().getId().equals(member.getId())) {
+            throw new GroupHandler(ErrorStatus.GROUP_INVITATION_NOT_FOUND);
+        }
+
+        Group group = invitation.getGroup();
+        groupValidator.validateExistMember(member, group);
+        groupValidator.validateGroupCount(group);
+
+        MemberGroup newMemberGroup = MemberGroupConverter.toMemberGroupEntity(member, group, GroupRole.MEMBER);
+        memberGroupRepository.save(newMemberGroup);
+        groupInvitationRepository.delete(invitation);
+    }
+
+    @Override
+    @Transactional
+    public void rejectInvitation(Member member, GroupRequestDto.InvitationActionRequestDto requestDto) {
+        GroupInvitation invitation = groupInvitationRepository.findById(requestDto.getInvitationId())
+                .orElseThrow(() -> new GroupHandler(ErrorStatus.GROUP_INVITATION_NOT_FOUND));
+
+        if (!invitation.getInvitedMember().getId().equals(member.getId())) {
+            throw new GroupHandler(ErrorStatus.GROUP_INVITATION_NOT_FOUND);
+        }
+
+        groupInvitationRepository.delete(invitation);
     }
 }

--- a/src/main/java/com/example/ohmobackend/service/groupService/GroupQueryService.java
+++ b/src/main/java/com/example/ohmobackend/service/groupService/GroupQueryService.java
@@ -9,7 +9,7 @@ import java.util.List;
 public interface GroupQueryService {
 
     public GroupResponseDto.GroupMembersDto getGroupMembers(Long groupId, Member member);
-
     public List<GroupResponseDto.GroupDto> getGroups(Member member);
     public void deleteGroup(Member member, GroupRequestDto.DeleteGroupRequestDto request);
+    public List<GroupResponseDto.InvitationDto> getInvitations(Member member);
 }

--- a/src/main/java/com/example/ohmobackend/service/groupService/GroupQueryServiceImpl.java
+++ b/src/main/java/com/example/ohmobackend/service/groupService/GroupQueryServiceImpl.java
@@ -4,8 +4,10 @@ import com.example.ohmobackend.apiPayload.code.status.ErrorStatus;
 import com.example.ohmobackend.apiPayload.exception.handler.GroupHandler;
 import com.example.ohmobackend.converter.GroupConverter;
 import com.example.ohmobackend.domain.Group;
+import com.example.ohmobackend.domain.GroupInvitation;
 import com.example.ohmobackend.domain.Member;
 import com.example.ohmobackend.domain.MemberGroup;
+import com.example.ohmobackend.repository.GroupInvitationRepository;
 import com.example.ohmobackend.repository.GroupRepository;
 import com.example.ohmobackend.repository.MemberGroupRepository;
 import com.example.ohmobackend.web.dto.groupDto.GroupRequestDto;
@@ -24,6 +26,7 @@ public class GroupQueryServiceImpl implements GroupQueryService {
 
     private final GroupRepository groupRepository;
     private final MemberGroupRepository memberGroupRepository;
+    private final GroupInvitationRepository groupInvitationRepository;
     private final GroupValidator groupValidator;
 
     public GroupResponseDto.GroupMembersDto getGroupMembers(Long groupId, Member member) {
@@ -54,5 +57,19 @@ public class GroupQueryServiceImpl implements GroupQueryService {
 
         groupValidator.validateMemberGroup(member, group);
         groupRepository.delete(group);
+    }
+
+    @Override
+    public List<GroupResponseDto.InvitationDto> getInvitations(Member member) {
+        List<GroupInvitation> invitations = groupInvitationRepository.findAllByInvitedMember(member);
+        return invitations.stream()
+                .map(invitation -> GroupResponseDto.InvitationDto.builder()
+                        .invitationId(invitation.getId())
+                        .groupId(invitation.getGroup().getId())
+                        .groupName(invitation.getGroup().getGroupName())
+                        .groupColor(invitation.getGroup().getGroupColor())
+                        .invitedByNickname(invitation.getInvitedBy().getNickname())
+                        .build())
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/ohmobackend/web/controller/GroupController.java
+++ b/src/main/java/com/example/ohmobackend/web/controller/GroupController.java
@@ -96,10 +96,31 @@ public class GroupController {
     }
 
     @PostMapping("/invite")
-    @Operation(summary = "멤버 초대 API", description = "방장이 멤버 ID로 특정 멤버를 그룹에 초대합니다.")
+    @Operation(summary = "멤버 초대 API", description = "방장이 이메일로 특정 멤버를 그룹에 초대합니다. 초대받은 멤버에게 FCM 알림이 전송됩니다.")
     public ApiResponse<Object> inviteMember(@AuthUser Member member, @Valid @RequestBody GroupRequestDto.InviteMemberRequestDto request) {
         groupCommandService.inviteMember(member, request);
         return ApiResponse.onSuccess(SuccessStatus.GROUP_INVITE_MEMBER_OK, null);
+    }
+
+    @GetMapping("/invite")
+    @Operation(summary = "받은 초대 목록 조회 API", description = "현재 로그인한 멤버가 받은 대기 중인 초대 목록을 조회합니다.")
+    public ApiResponse<List<GroupResponseDto.InvitationDto>> getInvitations(@AuthUser Member member) {
+        List<GroupResponseDto.InvitationDto> invitations = groupQueryService.getInvitations(member);
+        return ApiResponse.onSuccess(SuccessStatus.GROUP_INVITATION_LIST_OK, invitations);
+    }
+
+    @PostMapping("/invite/accept")
+    @Operation(summary = "그룹 초대 수락 API", description = "초대받은 멤버가 초대를 수락하면 그룹에 추가됩니다.")
+    public ApiResponse<Object> acceptInvitation(@AuthUser Member member, @Valid @RequestBody GroupRequestDto.InvitationActionRequestDto request) {
+        groupCommandService.acceptInvitation(member, request);
+        return ApiResponse.onSuccess(SuccessStatus.GROUP_INVITATION_ACCEPT_OK, null);
+    }
+
+    @PostMapping("/invite/reject")
+    @Operation(summary = "그룹 초대 거절 API", description = "초대받은 멤버가 초대를 거절합니다.")
+    public ApiResponse<Object> rejectInvitation(@AuthUser Member member, @Valid @RequestBody GroupRequestDto.InvitationActionRequestDto request) {
+        groupCommandService.rejectInvitation(member, request);
+        return ApiResponse.onSuccess(SuccessStatus.GROUP_INVITATION_REJECT_OK, null);
     }
 
     @GetMapping(value = "/{groupId}/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)

--- a/src/main/java/com/example/ohmobackend/web/dto/groupDto/GroupRequestDto.java
+++ b/src/main/java/com/example/ohmobackend/web/dto/groupDto/GroupRequestDto.java
@@ -85,7 +85,17 @@ public class GroupRequestDto {
         @NotNull
         private Long groupId;
         @NotNull
-        private Long targetMemberId;
+        private String targetEmail;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class InvitationActionRequestDto {
+        @NotNull
+        private Long invitationId;
     }
 
 }

--- a/src/main/java/com/example/ohmobackend/web/dto/groupDto/GroupResponseDto.java
+++ b/src/main/java/com/example/ohmobackend/web/dto/groupDto/GroupResponseDto.java
@@ -36,4 +36,16 @@ public class GroupResponseDto {
         private List<MemberGroupResponseDto.MemberGroupInfoDto> memberGroupInfos;
     }
 
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class InvitationDto {
+        private Long invitationId;
+        private Long groupId;
+        private String groupName;
+        private String groupColor;
+        private String invitedByNickname;
+    }
+
 }


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 초대 방식 멤버 ID → 이메일로 변경
- GroupInvitation 엔티티 추가 (초대 대기 상태 관리)
- 초대 수락/거절 API 추가 (POST /api/group/invite/accept, /reject)
- 받은 초대 목록 조회 API 추가 (GET /api/group/invite)
- 초대 시 FCM 알림에 invitationId 데이터 포함
- FcmNotificationType enum 추가

## 📌 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 리뷰를 원하는 부분 등을 적어주세요! -->
- 내용

### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #116


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Group invitation system: Members can now invite others to groups using email addresses instead of member IDs.
  * Invitation management: Users can view pending group invitations and choose to accept or reject them.
  * Push notifications: Invited members receive notifications when added to a group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->