### PR TITLE
fix: 회원가입 API 시큐리티 permitAll 매칭 오류 수정

### DIFF
--- a/src/main/java/com/example/ohmobackend/web/controller/MemberController.java
+++ b/src/main/java/com/example/ohmobackend/web/controller/MemberController.java
@@ -22,7 +22,7 @@ public class MemberController {
     private final MemberCommandService memberCommandService;
     private final AuthService authService;
 
-    @PostMapping(value = "/signup", consumes = "multipart/form-data")
+    @PostMapping("/signup")
     @Operation(summary = "이메일 회원 가입 API", description = "이메일 회원 가입 API 입니다.")
     public ApiResponse<MemberResponseDto.MemberInfoResponseDto> signup(
             @RequestPart("request") MemberRequestDto.SignupRequestDto request,


### PR DESCRIPTION
## 문제
`POST /api/member/signup`이 `WebSecurityConfig`에서 permitAll로 등록되어 있음에도 인증 없이 호출 시 빈 바디의 403이 발생 (Swagger/curl 모두 재현).

## 원인
`@PostMapping(value = "/signup", consumes = "multipart/form-data")`의 `consumes` 조건이, Spring Security의 `authorizeHttpRequests`가 내부적으로 사용하는 MVC `HandlerMappingIntrospector` 기반 경로 매칭과 충돌. 멀티파트 요청에 대해 이 조건이 제대로 평가되지 않아 permitAll 규칙이 매칭되지 않고 `anyRequest().authenticated()`로 떨어져 거부됨.

같은 방식으로 permitAll 처리되는 `/api/member/login`, `/api/member/password/find` (JSON, consumes 조건 없음)는 정상 동작하는 것으로 확인.

## 수정
`consumes = "multipart/form-data"` 제거. `@RequestPart` 바인딩은 이 속성 없이도 정상 동작하며, 라우팅 매칭에서 문제를 일으키는 조건만 제거됨.

## Test plan
- [ ] `POST /api/member/signup` (multipart, 인증 헤더 없이) → 200 확인
- [ ] `PATCH /api/member/profile-image` (multipart, 인증 필요) 기존대로 정상 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated signup request handling to accept requests without requiring a multipart form-data content type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->