### PR TITLE
chore: Redis 비밀번호/TLS 설정 지원 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,7 +30,10 @@ spring:
   data:
     redis:
       host: ${REDIS_HOST:localhost}
-      port: 6379
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}
+      ssl:
+        enabled: ${REDIS_SSL_ENABLED:false}
   mail:
     host: smtp.gmail.com
     port: 587


### PR DESCRIPTION
## 배경
EC2 비용 절감을 위해 Render로 마이그레이션 예정. Render는 무료 매니지드 Redis가 없어서 Upstash 같은 외부 서비스로 옮겨야 하는데, Upstash는 TLS+비밀번호 인증이 필수라 기존 설정(host+port만)으로는 연결이 안 됨.

## 변경 사항
`application.yml`의 `spring.data.redis`에 `password`, `ssl.enabled` 추가. 둘 다 값 미설정 시 기존 동작(무인증, TLS 없음)과 동일하게 동작하도록 기본값을 비워둠 — 로컬 개발/현재 EC2 배포 환경에는 영향 없음.

## 테스트
- `./gradlew compileJava` 로컬 컴파일 확인
- Redis 관련 코드(`RedisCacheConfig`, `AuthServiceImpl`)는 Spring Boot 오토컨피그(`RedisConnectionFactory`)에 의존하는 구조라 별도 Java 코드 변경 없이 프로퍼티만으로 적용됨

## 다음 단계 (이 PR 범위 밖)
- Render에 Upstash 연결 시 `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD`, `REDIS_SSL_ENABLED=true` 환경변수 설정 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Redis connection settings for port, password, and SSL.
  * Redis now defaults to port 6379 when no port is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->