### PR TITLE
[FIX] 메일 발송을 SendGrid API 기반으로 교체

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,6 @@ dependencies {
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.797'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
-    implementation 'org.springframework.boot:spring-boot-starter-mail'
     testImplementation 'com.h2database:h2'
     implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
     implementation 'org.springframework.boot:spring-boot-starter-aop'

--- a/src/main/java/com/example/ohmobackend/config/RestClientConfig.java
+++ b/src/main/java/com/example/ohmobackend/config/RestClientConfig.java
@@ -18,4 +18,14 @@ public class RestClientConfig {
         factory.setReadTimeout(readTimeout);
         return new RestTemplate(factory);
     }
+
+    @Bean
+    public RestTemplate sendGridRestTemplate(
+            @Value("${sendgrid.connect-timeout}") int connectTimeout,
+            @Value("${sendgrid.read-timeout}") int readTimeout) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(connectTimeout);
+        factory.setReadTimeout(readTimeout);
+        return new RestTemplate(factory);
+    }
 }

--- a/src/main/java/com/example/ohmobackend/service/emailService/EmailServiceImpl.java
+++ b/src/main/java/com/example/ohmobackend/service/emailService/EmailServiceImpl.java
@@ -2,35 +2,63 @@ package com.example.ohmobackend.service.emailService;
 
 import com.example.ohmobackend.apiPayload.code.status.ErrorStatus;
 import com.example.ohmobackend.apiPayload.exception.handler.AuthHandler;
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
-import lombok.RequiredArgsConstructor;
-import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
 
 @Service
-@RequiredArgsConstructor
 public class EmailServiceImpl implements EmailService {
 
-    private final JavaMailSender mailSender;
+    private static final String SENDGRID_ENDPOINT = "https://api.sendgrid.com/v3/mail/send";
+
+    private final RestTemplate sendGridRestTemplate;
+
+    @Value("${sendgrid.api-key}")
+    private String apiKey;
+
+    @Value("${sendgrid.from-email}")
+    private String fromEmail;
+
+    public EmailServiceImpl(@Qualifier("sendGridRestTemplate") RestTemplate sendGridRestTemplate) {
+        this.sendGridRestTemplate = sendGridRestTemplate;
+    }
 
     @Override
     public void sendVerificationCode(String toEmail, String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(apiKey);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, Object> body = Map.of(
+                "personalizations", List.of(Map.of("to", List.of(Map.of("email", toEmail)))),
+                "from", Map.of("email", fromEmail),
+                "subject", "[Oh-Mo] 비밀번호 찾기 인증 코드",
+                "content", List.of(Map.of(
+                        "type", "text/html",
+                        "value",
+                        "<p>안녕하세요, Oh-Mo입니다.</p>"
+                                + "<p>비밀번호 재설정을 위한 인증 코드입니다.</p>"
+                                + "<h2>" + code + "</h2>"
+                                + "<p>해당 코드는 <strong>5분간</strong> 유효합니다.</p>"
+                ))
+        );
+
         try {
-            MimeMessage message = mailSender.createMimeMessage();
-            MimeMessageHelper helper = new MimeMessageHelper(message, false, "UTF-8");
-            helper.setTo(toEmail);
-            helper.setSubject("[Oh-Mo] 비밀번호 찾기 인증 코드");
-            helper.setText(
-                    "<p>안녕하세요, Oh-Mo입니다.</p>" +
-                    "<p>비밀번호 재설정을 위한 인증 코드입니다.</p>" +
-                    "<h2>" + code + "</h2>" +
-                    "<p>해당 코드는 <strong>5분간</strong> 유효합니다.</p>",
-                    true
-            );
-            mailSender.send(message);
-        } catch (MessagingException e) {
+            ResponseEntity<String> response = sendGridRestTemplate.postForEntity(
+                    SENDGRID_ENDPOINT, new HttpEntity<>(body, headers), String.class);
+            if (!response.getStatusCode().is2xxSuccessful()) {
+                throw new AuthHandler(ErrorStatus.EMAIL_SEND_FAILED);
+            }
+        } catch (RestClientException e) {
             throw new AuthHandler(ErrorStatus.EMAIL_SEND_FAILED);
         }
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,23 +34,17 @@ spring:
       password: ${REDIS_PASSWORD:}
       ssl:
         enabled: ${REDIS_SSL_ENABLED:false}
-  mail:
-    host: smtp.gmail.com
-    port: 587
-    username: ${MAIL_USERNAME}
-    password: ${MAIL_PASSWORD}
-    properties:
-      mail:
-        smtp:
-          auth: true
-          starttls:
-            enable: true
-
 jwt:
   secret: ${JWT_SECRET_KEY}
 
 nlp:
   api-url: "http://localhost:8000"
+  connect-timeout: 3000
+  read-timeout: 10000
+
+sendgrid:
+  api-key: ${SENDGRID_API_KEY}
+  from-email: ${SENDGRID_FROM_EMAIL}
   connect-timeout: 3000
   read-timeout: 10000
 


### PR DESCRIPTION
## Summary
- Render Free 웹서비스가 아웃바운드 SMTP(587)를 막아 Gmail SMTP 연결이 타임아웃되던 문제 해결
- `JavaMailSender`/`spring-boot-starter-mail` 제거, SendGrid REST API(`POST https://api.sendgrid.com/v3/mail/send`, HTTPS 443)를 `RestTemplate`으로 직접 호출하는 방식으로 교체
- `RestClientConfig`에 기존 `nlpRestTemplate` 패턴과 동일하게 `sendGridRestTemplate` bean 추가 (connect/read timeout 분리)
- env var 추가 필요: `SENDGRID_API_KEY`, `SENDGRID_FROM_EMAIL`
- `EmailService` 인터페이스는 그대로 유지해 호출부(`AuthServiceImpl` 등) 수정 없음

Closes #126

## 배포 전 필요한 작업 (브라우저 작업, 별도 진행)
- [ ] SendGrid 계정 생성
- [ ] Single Sender Verification으로 발신 이메일 인증
- [ ] API Key 발급
- [ ] Render 환경변수에 `SENDGRID_API_KEY`, `SENDGRID_FROM_EMAIL` 추가
- [ ] 기존 `MAIL_USERNAME`/`MAIL_PASSWORD` env var는 더 이상 안 쓰므로 정리 가능

## Test plan
- [x] `./gradlew compileJava` 통과
- [ ] Render 재배포 후 실제 비밀번호 찾기 인증 코드 메일 수신 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Verification emails are now sent through the SendGrid email service.
  * Added configurable connection and response timeouts for email delivery.

* **Bug Fixes**
  * Improved email delivery error handling by reporting failures consistently when the email service returns an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->